### PR TITLE
making sure that path.normalize gets strings

### DIFF
--- a/tasks/cache_invalidate.js
+++ b/tasks/cache_invalidate.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
     var FILE_FORMAT_REGEX = /^(.+?)\.(\w+?)$/;
 
     function isPathEqual(p1, p2) {
-        return path.normalize(p1) === path.normalize(p2);
+        return path.normalize(p1.toString()) === path.normalize(p2.toString());
     }
 
     function escapeRegExp(str) {


### PR DESCRIPTION
I've ran in to weird problems on a Linux box using a deprecated NodeJS version.

Problem was:
Warning: Object dist/index.html has no method 'charAt' Use --force to continue.
TypeError: Object dist/index.html has no method 'charAt'
  at Object.exports.normalize (path.js:336:27)
  at isPathEqual (/export/home/WWW/ci/workspace/BFS-T01-build_test/node_modules/grunt-cache-invalidate/tasks/cache_invalidate.js:21:44)
